### PR TITLE
fix: total borrow balance should include VAI

### DIFF
--- a/src/containers/Main/Dashboard.js
+++ b/src/containers/Main/Dashboard.js
@@ -76,7 +76,7 @@ function Dashboard({ settings, setSetting }) {
       ]);
 
       let totalBorrowLimit = new BigNumber(0);
-      let totalBorrowBalance = new BigNumber(0);
+      let totalBorrowBalance = new BigNumber(userVaiMinted);
       
       const assetList = await Promise.all(Object.values(constants.CONTRACT_TOKEN_ADDRESS).map(async (item, index) => {
         if (!settings.decimals[item.id]) {


### PR DESCRIPTION
Right now `totalBorrowBalance` does not include the `userVaiMinted` in any location. 
Only the **WalletBalance** component shows correct value because we manually add `userVaiMinted` to the `totalBorrowed` there.

This change should fix the `totalBorrowBalance` in all the components on the **Dashboard**. 